### PR TITLE
Add routing primitives

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -4,5 +4,6 @@
 npm-debug.log
 *.bs.js
 
+/coverage/
 /lib/bs/
 /node_modules/

--- a/app/__tests__/App_test.re
+++ b/app/__tests__/App_test.re
@@ -7,7 +7,7 @@ let () =
   test("App renders heading", () =>
     <App />
     |> render
-    |> getByText(~matcher=`Str("Governance MVP"))
+    |> getByText(~matcher=`Str("Home of Oscoin"))
     |> expect
     |> toBeInTheDocument
   );

--- a/app/__tests__/lib/Router_test.re
+++ b/app/__tests__/lib/Router_test.re
@@ -1,0 +1,16 @@
+open Jest;
+
+describe("Router", () =>
+  Expect.(
+    ReasonReactRouter.(
+      Router.(
+        test("pageOfUrl", () => {
+          let url = {hash: "", path: ["projects"], search: ""};
+          let page = pageOfUrl(url);
+
+          expect(page) |> toBe(Projects);
+        })
+      )
+    )
+  )
+);

--- a/app/__tests__/lib/Router_test.re
+++ b/app/__tests__/lib/Router_test.re
@@ -1,16 +1,24 @@
 open Jest;
+open Expect;
+open ReasonReactRouter;
+open Router;
 
 describe("Router", () =>
-  Expect.(
-    ReasonReactRouter.(
-      Router.(
-        test("pageOfUrl", () => {
-          let url = {hash: "", path: ["projects"], search: ""};
-          let page = pageOfUrl(url);
-
-          expect(page) |> toBe(Projects);
-        })
-      )
-    )
+  testAll(
+    "pageOfUrl",
+    [
+      (Root, {hash: "", path: [], search: ""}),
+      (Projects, {hash: "", path: ["projects"], search: ""}),
+      (
+        NotFound(["not-found"]),
+        {hash: "", path: ["not-found"], search: ""},
+      ),
+      (
+        NotFound(["utter", "crap"]),
+        {hash: "", path: ["utter", "crap"], search: ""},
+      ),
+    ],
+    ((page, url)) =>
+    expect(pageOfUrl(url)) |> toEqual(page)
   )
 );

--- a/app/bsconfig.json
+++ b/app/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-hooks-template",
+  "name": "oscoin",
   "reason": {
     "react-jsx": 3
   },

--- a/app/src/App.re
+++ b/app/src/App.re
@@ -5,7 +5,7 @@ let make = () => {
   let url = ReasonReactRouter.useUrl();
   let page =
     switch (pageOfUrl(url)) {
-    | Home => <Generic title="Home of Oscoin" />
+    | Root => <Generic title="Home of Oscoin" />
     | Projects => <Generic title="List of projects" />
     | NotFound(_path) => <Generic title="Not Found" />
     };

--- a/app/src/App.re
+++ b/app/src/App.re
@@ -1,2 +1,14 @@
 [@react.component]
-let make = () => <h1> {React.string("Governance MVP")} </h1>;
+let make = () => {
+  open Router;
+
+  let url = ReasonReactRouter.useUrl();
+  let page =
+    switch (pageOfUrl(url)) {
+    | Home => <Generic title="Home of Oscoin" />
+    | Projects => <Generic title="List of projects" />
+    | NotFound(_path) => <Generic title="Not Found" />
+    };
+
+  <div className="app"> <Navigation /> page </div>;
+};

--- a/app/src/components/Navigation.re
+++ b/app/src/components/Navigation.re
@@ -15,4 +15,4 @@ module Item = {
 };
 
 [@react.component]
-let make = () => <ul> <Item page=Home /> <Item page=Projects /> </ul>;
+let make = () => <ul> <Item page=Root /> <Item page=Projects /> </ul>;

--- a/app/src/components/Navigation.re
+++ b/app/src/components/Navigation.re
@@ -1,0 +1,18 @@
+open Router;
+
+module Item = {
+  [@react.component]
+  let make = (~page: page) => {
+    let link = linkOfPage(page);
+    let name = nameOfPage(page);
+
+    <li>
+      <a onClick={_ => ReasonReactRouter.push(link)}>
+        {React.string(name)}
+      </a>
+    </li>;
+  };
+};
+
+[@react.component]
+let make = () => <ul> <Item page=Home /> <Item page=Projects /> </ul>;

--- a/app/src/lib/Router.re
+++ b/app/src/lib/Router.re
@@ -1,27 +1,27 @@
 open ReasonReactRouter;
 
 type page =
-  | Home
+  | Root
   | Projects
   | NotFound(list(string));
 
 let linkOfPage = (p: page): string =>
   switch (p) {
-  | Home => "/"
+  | Root => "/"
   | Projects => "/projects"
   | NotFound(_path) => "/not-found"
   };
 
 let nameOfPage = (p: page): string =>
   switch (p) {
-  | Home => "Home"
+  | Root => "Root"
   | Projects => "Projects"
   | NotFound(_path) => "Not Found"
   };
 
 let pageOfUrl = (u: url): page =>
   switch (u.path) {
-  | [] => Home
+  | [] => Root
   | ["projects"] => Projects
   | ["not-found"] => NotFound(u.path)
   | _ => NotFound(u.path)

--- a/app/src/lib/Router.re
+++ b/app/src/lib/Router.re
@@ -1,0 +1,28 @@
+open ReasonReactRouter;
+
+type page =
+  | Home
+  | Projects
+  | NotFound(list(string));
+
+let linkOfPage = (p: page): string =>
+  switch (p) {
+  | Home => "/"
+  | Projects => "/projects"
+  | NotFound(_path) => "/not-found"
+  };
+
+let nameOfPage = (p: page): string =>
+  switch (p) {
+  | Home => "Home"
+  | Projects => "Projects"
+  | NotFound(_path) => "Not Found"
+  };
+
+let pageOfUrl = (u: url): page =>
+  switch (u.path) {
+  | [] => Home
+  | ["projects"] => Projects
+  | ["not-found"] => NotFound(u.path)
+  | _ => NotFound(u.path)
+  };

--- a/app/src/lib/Router.rei
+++ b/app/src/lib/Router.rei
@@ -1,0 +1,8 @@
+type page =
+  | Home
+  | Projects
+  | NotFound(list(string));
+
+let linkOfPage: page => string;
+let nameOfPage: page => string;
+let pageOfUrl: ReasonReactRouter.url => page;

--- a/app/src/lib/Router.rei
+++ b/app/src/lib/Router.rei
@@ -1,5 +1,5 @@
 type page =
-  | Home
+  | Root
   | Projects
   | NotFound(list(string));
 

--- a/app/src/pages/Generic.re
+++ b/app/src/pages/Generic.re
@@ -1,0 +1,2 @@
+[@react.component]
+let make = (~title: string) => <h1> {React.string(title)} </h1>;


### PR DESCRIPTION
This change adds routing primitives by means of a Router module which exposes the necessary building blocks to translate from urls to endpoint and build links to endpoints. At the core is the page variant which assumed along screens as coarse unit to route to. These pages can then be used to vary on them in the display logic of the main app. In turn the pages are used to construct working links to build up navigations and references throughout the app.

* implement Router module
* add Router type declarations
* use stop-gap Generic page
* build minimal navigation component