### PR TITLE
Implement project sub navigation

### DIFF
--- a/app/src/App.re
+++ b/app/src/App.re
@@ -2,11 +2,13 @@
 let make = () => {
   open Router;
 
-  let url = ReasonReactRouter.useUrl();
   let page =
-    switch (pageOfUrl(url)) {
+    switch (currentPage()) {
     | Root => <Generic title="Home of Oscoin" />
     | Projects => <Generic title="List of projects" />
+    | Project(id) => <Project id subPage=Project.Overview />
+    | ProjectCode(id) => <Project id subPage=Project.Code />
+    | ProjectFunds(id) => <Project id subPage=Project.Funds />
     | NotFound(_path) => <Generic title="Not Found" />
     };
 

--- a/app/src/components/Navigation.re
+++ b/app/src/components/Navigation.re
@@ -3,16 +3,16 @@ open Router;
 module Item = {
   [@react.component]
   let make = (~page: page) => {
-    let link = linkOfPage(page);
     let name = nameOfPage(page);
 
-    <li>
-      <a onClick={_ => ReasonReactRouter.push(link)}>
-        {React.string(name)}
-      </a>
-    </li>;
+    <li> <a onClick={navigateOfPage(page)}> {React.string(name)} </a> </li>;
   };
 };
 
 [@react.component]
-let make = () => <ul> <Item page=Root /> <Item page=Projects /> </ul>;
+let make = () =>
+  <ul>
+    <Item page=Root />
+    <Item page=Projects />
+    <Item page={Project("monokel")} />
+  </ul>;

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -7,6 +7,6 @@
 <body>
   <div id="app"></div>
 
-  <script src="Index.js"></script>
+  <script src="/Index.js"></script>
 </body>
 </html>

--- a/app/src/lib/Router.re
+++ b/app/src/lib/Router.re
@@ -3,19 +3,35 @@ open ReasonReactRouter;
 type page =
   | Root
   | Projects
+  | Project(string)
+  | ProjectCode(string)
+  | ProjectFunds(string)
   | NotFound(list(string));
 
-let linkOfPage = (p: page): string =>
-  switch (p) {
-  | Root => "/"
-  | Projects => "/projects"
-  | NotFound(_path) => "/not-found"
-  };
+let navigateOfPage = (p: page) => {
+  let join = (parts: list(string)): string =>
+    List.fold_left((a, b) => a ++ "/" ++ b, "", parts);
+
+  let link =
+    switch (p) {
+    | Root => "/"
+    | Projects => join(["projects"])
+    | Project(id) => join(["projects", id])
+    | ProjectCode(id) => join(["projects", id, "code"])
+    | ProjectFunds(id) => join(["projects", id, "funds"])
+    | NotFound(_path) => "/not-found"
+    };
+
+  _ => ReasonReactRouter.push(link);
+};
 
 let nameOfPage = (p: page): string =>
   switch (p) {
   | Root => "Root"
   | Projects => "Projects"
+  | Project(id) => "Project " ++ id
+  | ProjectCode(id) => "Project " ++ id ++ "Code"
+  | ProjectFunds(id) => "Project " ++ id ++ "Funds"
   | NotFound(_path) => "Not Found"
   };
 
@@ -23,6 +39,14 @@ let pageOfUrl = (u: url): page =>
   switch (u.path) {
   | [] => Root
   | ["projects"] => Projects
+  | ["projects", id] => Project(id)
+  | ["projects", id, "code"] => ProjectCode(id)
+  | ["projects", id, "funds"] => ProjectFunds(id)
   | ["not-found"] => NotFound(u.path)
   | _ => NotFound(u.path)
   };
+
+let currentPage = (): page => {
+  let url = ReasonReactRouter.useUrl();
+  pageOfUrl(url);
+};

--- a/app/src/lib/Router.rei
+++ b/app/src/lib/Router.rei
@@ -1,8 +1,24 @@
+/** Routable pages which relate to larger context of features. **/
 type page =
   | Root
   | Projects
+  | Project(string)
+  | ProjectCode(string)
+  | ProjectFunds(string)
   | NotFound(list(string));
 
-let linkOfPage: page => string;
+/** Reads the current url and return a matching page, or NotFound. **/
+let currentPage: unit => page;
+
+/** Given a page returns a function which nvigates to it by pushing a new url
+ ** onto the pushState.
+ **/
+let navigateOfPage: (page, 'a) => unit;
+
+/** Returns a human readable string for the given page, which can be used in
+ ** navigations and other linking references.
+ **/
 let nameOfPage: page => string;
+
+/** Given a ReasonReactRouter.url returns a matching page, or NotFound **/
 let pageOfUrl: ReasonReactRouter.url => page;

--- a/app/src/lib/Router.rei
+++ b/app/src/lib/Router.rei
@@ -10,7 +10,7 @@ type page =
 /** Reads the current url and return a matching page, or NotFound. **/
 let currentPage: unit => page;
 
-/** Given a page returns a function which nvigates to it by pushing a new url
+/** Given a page returns a function which navigates to it by pushing a new url
  ** onto the pushState.
  **/
 let navigateOfPage: (page, 'a) => unit;

--- a/app/src/pages/Project.re
+++ b/app/src/pages/Project.re
@@ -1,0 +1,39 @@
+type projectPage =
+  | Overview
+  | Code
+  | Funds;
+
+module Navigation = {
+  open Router;
+
+  module Item = {
+    [@react.component]
+    let make = (~id: string, ~page: projectPage, ~selected: projectPage) => {
+      let (navigate, name) =
+        switch (page) {
+        | Overview => (navigateOfPage(Project(id)), "Overview")
+        | Code => (navigateOfPage(ProjectCode(id)), "Code")
+        | Funds => (navigateOfPage(ProjectFunds(id)), "Funds")
+        };
+
+      let name = page == selected ? name ++ " <" : name;
+
+      <li> <a onClick=navigate> {React.string(name)} </a> </li>;
+    };
+  };
+
+  [@react.component]
+  let make = (~id: string, ~subPage: projectPage) =>
+    <ul>
+      <Item id page=Overview selected=subPage />
+      <Item id page=Code selected=subPage />
+      <Item id page=Funds selected=subPage />
+    </ul>;
+};
+
+[@react.component]
+let make = (~id: string, ~subPage: projectPage) =>
+  <>
+    <h1> {React.string("Project " ++ id)} </h1>
+    <Navigation id subPage />
+  </>;


### PR DESCRIPTION
As an exercise and we have to support multiple functional contexts within a project this change explores how a sub navigation with associated routes can look like. It leaves the main composition to the App component and enabls differnt sub pages with a prop passed to a page. Along the way it entirely hides the internal use of ReasonReactRouter in the Router module by exposing `currentPage` and instead of returning a raw string, that can be used as a link, it returns a function that can be invoked when the new pushState should take effect.

* implement Project component
* use props to enable Project sub page routing
* show simple project navigation which shows active "tab"
* use `currentPage` as the main routing interface
* move from raw strings to `navigate` functions to be used by components
which want to build links